### PR TITLE
Add metabase initial setup feature

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -46,12 +46,6 @@ jobs:
       - name: check out the codebase.
         uses: actions/checkout@v2
 
-      - name: login to docker hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-
       - name: install kubectl
         uses: azure/setup-kubectl@v3
 
@@ -72,8 +66,30 @@ jobs:
       - name: install make
         run: sudo apt-get install -y make
 
-      - name: run molecule tests
-        run: ./bin/test
+      - name: create molecule test scenario
+        run: make molecule create -- -s ${{ matrix.scenario }}
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          KIND_RELEASE: ${{ matrix.release }}
+          KIND_IMAGE: ${{ matrix.image }}
+
+      - name: publish test images
+        run: make images
+
+      - name: converge molecule test scenario
+        run: make molecule converge -- -s ${{ matrix.scenario }}
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          KIND_RELEASE: ${{ matrix.release }}
+          KIND_IMAGE: ${{ matrix.image }}
+
+      - name: restart strimzi connectors
+        run: make strimzi-connector-restart
+
+      - name: verify molecule test scenario
+        run: make molecule verify -- -s ${{ matrix.scenario }}
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'

--- a/charts/dataplane/Chart.yaml
+++ b/charts/dataplane/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dataplane/templates/_helpers.tpl
+++ b/charts/dataplane/templates/_helpers.tpl
@@ -182,7 +182,7 @@ Metabase DB name
 {{/*
 Metabase DB user secret
  */}}
-{{- define "dataplane.metabase.secret" -}}
+{{- define "dataplane.metabase.db.secret" -}}
 {{ .Values.zalando.metabase.user }}-{{- include "dataplane.metabase.cluster" . -}}
 {{- end }}
 
@@ -208,9 +208,9 @@ Warehouse DB user secret
 {{- end }}
 
 {{/*
-TLS secret name
+Metabase TLS secret name
 */}}
-{{- define "dataplane.metabase.ingress.secretName" -}}
+{{- define "dataplane.metabase.ingress.secret.name" -}}
 {{- if .Values.metabase.ingress.secretName }}
 {{- .Values.metabase.ingress.secretName }}
 {{- else }}
@@ -219,26 +219,26 @@ TLS secret name
 {{- end }}
 
 {{/*
-API secret name
+Metabase setup secret name
 */}}
-{{- define "dataplane.metabase.api.secret.name" -}}
+{{- define "dataplane.metabase.setup.secret.name" -}}
 {{- (printf "%s-%s" (include "dataplane.release" .) "metabase-api-token") -}}
 {{- end }}
 
 {{/*
-Stable API secret data
+Metabase setup secret data
 */}}
-{{- define "dataplane.metabase.api.secret" -}}
-{{- $secret := lookup "v1" "Secret" .Release.Namespace (include "dataplane.metabase.api.secret.name" .) -}}
+{{- define "dataplane.metabase.setup.secret.data" -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace (include "dataplane.metabase.setup.secret.name" .) -}}
 {{- if $secret -}}
 {{/*
-   Reusing existing secret data
+   Reuse existing secret data
 */}}
-apiKey: {{ $secret.data.apiKey }}
+adminPassword: {{ $secret.data.adminPassword }}
 {{- else -}}
 {{/*
     Generate new secret
 */}}
-apiKey: {{ randAlphaNum 16 | b64enc }}
+adminPassword: {{ randAlphaNum 16 | b64enc }}
 {{- end -}}
 {{- end -}}

--- a/charts/dataplane/templates/metabase/deployment.yaml
+++ b/charts/dataplane/templates/metabase/deployment.yaml
@@ -28,10 +28,44 @@ spec:
       securityContext:
         {{- toYaml .Values.metabase.podSecurityContext | nindent 8 }}
       containers:
+        {{- if .Values.metabase.initialSetup.enabled }}
+        - name: metabase-init
+          securityContext:
+            {{- toYaml .Values.metabase.initialSetup.securityContext | nindent 12 }}
+          image: "{{ .Values.initialSetup.image.repository }}:{{ .Values.initialSetup.image.tag }}"
+          imagePullPolicy: {{ .Values.metabase.initialSetup.image.pullPolicy }}
+          resources:
+            requests:
+              cpu: 500m
+              memory: 200Mi
+            limits:
+              cpu: 500m
+              memory: 200Mi
+          env:
+            - name: "INIT_RETRIES"
+              value: {{ .Values.metabase.initialSetup.retries }}
+            - name: "INIT_BACKOFF_SECONDS"
+              value: {{ .Values.metabase.initialSetup.backoffSeconds }}
+            - name: "MB_SITE_URL"
+              value: "https://{{ .Values.metabase.ingress.hostName }}"
+            - name: "MB_ADMIN_FIRSTNAME"
+              value: {{ .Values.metabase.initialSetup.user.firstName }}
+            - name: "MB_ADMIN_LASTNAME"
+              value: {{ .Values.metabase.initialSetup.user.lastName }}
+            - name: "MB_ADMIN_EMAIL"
+              value: {{ .Values.metabase.initialSetup.user.email }}
+            - name: "MB_ADMIN_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "dataplane.metabase.setup.secret.name" . }}
+                  key: adminPassword
+          command: ['python', 'setup.py']
+          args: ['--url=$(MB_SITE_URL)', '--setup-email=$(MB_ADMIN_EMAIL)', '--setup-firstname=$(MB_ADMIN_FIRSTNAME)', '--setup-lastname=$(MB_ADMIN_LASTNAME)', '--setup-password=$(MB_ADMIN_PASSWORD)', '--retries=$(INIT_RETRIES', '--backoff-in-seconds=$(INIT_BACKOFF_SECONDS)']
+        {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.metabase.securityContext | nindent 12 }}
-          image: "{{ .Values.metabase.image.repository }}:{{ .Values.metabase.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.metabase.image.repository }}:{{ .Values.metabase.image.tag }}"
           imagePullPolicy: {{ .Values.metabase.image.pullPolicy }}
           ports:
             - name: http
@@ -59,12 +93,12 @@ spec:
             - name: "MB_DB_USER"
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "dataplane.metabase.secret" . }}
+                  name: {{ include "dataplane.metabase.db.secret" . }}
                   key: username
             - name: "MB_DB_PASS"
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "dataplane.metabase.secret" . }}
+                  name: {{ include "dataplane.metabase.db.secret" . }}
                   key: password
           {{- with .Values.metabase.podEnvironmentVars }}
             {{- toYaml . | nindent 12 }}

--- a/charts/dataplane/templates/metabase/deployment.yaml
+++ b/charts/dataplane/templates/metabase/deployment.yaml
@@ -60,7 +60,7 @@ spec:
                   name: {{ include "dataplane.metabase.setup.secret.name" . }}
                   key: adminPassword
           command: ['python', 'setup.py']
-          args: ['--url=$(MB_SITE_URL)', '--setup-email=$(MB_ADMIN_EMAIL)', '--setup-firstname=$(MB_ADMIN_FIRSTNAME)', '--setup-lastname=$(MB_ADMIN_LASTNAME)', '--setup-password=$(MB_ADMIN_PASSWORD)', '--retries=$(INIT_RETRIES', '--backoff-in-seconds=$(INIT_BACKOFF_SECONDS)']
+          args: ['--url=$(MB_SITE_URL)', '--setup-email=$(MB_ADMIN_EMAIL)', '--setup-firstname=$(MB_ADMIN_FIRSTNAME)', '--setup-lastname=$(MB_ADMIN_LASTNAME)', '--setup-password=$(MB_ADMIN_PASSWORD)', '--retries=$(INIT_RETRIES)', '--backoff-in-seconds=$(INIT_BACKOFF_SECONDS)']
         {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/dataplane/templates/metabase/ingress.yaml
+++ b/charts/dataplane/templates/metabase/ingress.yaml
@@ -1,7 +1,7 @@
 ---
 {{- if .Values.metabase.ingress.enabled -}}
 {{- $fullName := include "dataplane.metabase.fullname" . -}}
-{{- $secretName := include "dataplane.metabase.ingress.secretName" . -}}
+{{- $secretName := include "dataplane.metabase.ingress.secret.name" . -}}
 {{- $svcPort := .Values.metabase.service.port -}}
 {{- if and .Values.metabase.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.metabase.ingress.annotations "kubernetes.io/ingress.class") }}

--- a/charts/dataplane/templates/metabase/secret.yaml
+++ b/charts/dataplane/templates/metabase/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "dataplane.metabase.api.secret.name" . }}
+  name: {{ include "dataplane.metabase.setup.secret.name" . }}
 type: Opaque
 data:
-{{- ( include "dataplane.metabase.api.secret" . ) | indent 2 -}}
+{{- ( include "dataplane.metabase.setup.secret.data" . ) | indent 2 -}}

--- a/charts/dataplane/values.yaml
+++ b/charts/dataplane/values.yaml
@@ -76,6 +76,24 @@ metabase:
 
   replicaCount: 2
 
+  initialSetup:
+    enabled: true
+
+    image:
+      repository: josesolisrosales/metabase-init
+      pullPolicy: Always
+      tag: "1.1.0"
+
+    retries: 6
+    backoffSeconds: 2
+
+    user:
+      firstName: John
+      lastName: Doe
+      email: jdoe@test.test
+
+    securityContext: {}
+
   image:
     repository: metabase/metabase
     pullPolicy: IfNotPresent

--- a/dataplane/cli.py
+++ b/dataplane/cli.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-
-def main():
-    print('metabase init')
-
-if __name__ == "__main__":
-    main()

--- a/dataplane/metabase/__init__.py
+++ b/dataplane/metabase/__init__.py
@@ -1,1 +1,0 @@
-#!/usr/bin/env python3


### PR DESCRIPTION
- Adds metabase initial setup using `josesolisrosales/metabase-init` as the initial setup container image
- Bumps chart version
- Reconciles changes with init branch in main repository (except changes related to metabase-init *container* as the container is being built elsewhere)